### PR TITLE
Dry tests

### DIFF
--- a/src/main/assembly/dist/bin/easy-license-creator
+++ b/src/main/assembly/dist/bin/easy-license-creator
@@ -1,4 +1,19 @@
 #!/usr/bin/env bash
+#
+# Copyright (C) 2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 BINPATH=`readlink -f $0`
 APPHOME=`dirname \`dirname $BINPATH \``

--- a/src/test/scala/nl/knaw/dans/easy/license/app/CommandLineOptionsSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/license/app/CommandLineOptionsSpec.scala
@@ -53,23 +53,20 @@ class CommandLineOptionsSpec extends UnitSpec {
 
   it should "fail when the outputFile is missing" in {
     val args = "easy-dataset:1".split(" ")
-    var errorMessage: String = ""
-    val opts = new CommandLineOptions(args) {
-      errorMessageHandler = (s: String) => errorMessage = s
-    }
-    opts.verify()
-
-    errorMessage should include ("license-file")
+    commandLineErrorMessage(args) should include ("license-file")
   }
 
   it should "fail when invalid arguments are given" in {
     val args = "--invalidArg easy-dataset:1 src/test/resources/license.pdf".split(" ")
+    commandLineErrorMessage(args) should include ("invalidArg")
+  }
+
+  def commandLineErrorMessage(args: Array[String]): String = {
     var errorMessage: String = ""
     val opts = new CommandLineOptions(args) {
       errorMessageHandler = (s: String) => errorMessage = s
     }
     opts.verify()
-
-    errorMessage should include ("invalidArg")
+    errorMessage
   }
 }


### PR DESCRIPTION
First of all: great you found this solution.

Second: `run.sh` is meant to mimic the deployed script in your development environment, though it still requires a `mvn clean install`.

Third: perhaps the readme checks could be done in a similar way (with `--help` for `args`), rather than the current hack in other projects.